### PR TITLE
Add options to manually specify tokens for processors

### DIFF
--- a/EazFixer/Flags.cs
+++ b/EazFixer/Flags.cs
@@ -1,10 +1,23 @@
+using dnlib.DotNet;
+
 namespace EazFixer {
     internal class Flags
     {
-        public static string InFile;
-        public static string OutFile;
+        public static string  InFile;
+        public static string  OutFile;
 
-        public static bool   KeepTypes;
-        public static bool   VirtFix;
+        public static bool    KeepTypes;
+        public static bool    VirtFix;
+        public static bool    PreserveAll;
+        
+        public static MDToken StrDecTok;
+        public static MDToken ResResolverTok;
+        public static MDToken ResInitTok;
+        public static MDToken AsmResTypeTok;
+        public static MDToken AsmResMoveNextTok;
+        public static MDToken AsmResDecompressTok;
+        public static MDToken AsmResDecryptTok;
+        
+        public static bool    IgnoreTokVerification;
     }
 }

--- a/EazFixer/Flags.cs
+++ b/EazFixer/Flags.cs
@@ -17,7 +17,5 @@ namespace EazFixer {
         public static MDToken AsmResMoveNextTok;
         public static MDToken AsmResDecompressTok;
         public static MDToken AsmResDecryptTok;
-        
-        public static bool    IgnoreTokVerification;
     }
 }

--- a/EazFixer/Options.cs
+++ b/EazFixer/Options.cs
@@ -41,9 +41,5 @@ namespace EazFixer
         
         [Option("asmres-decrypt-tok", Default = "0", HelpText = "Manually specify assembly decryptor method token for if detection fails (Format: 0x<token>) ")]
         public string AsmResDecryptTok { get; set; }
-        
-        [Option("ignore-tok-verification", HelpText = "Ignore the verification of manually set tokens. (Ensure your tokens are correct!)")]
-        public bool IgnoreTokVerification { get; set; }
-
     }
 }

--- a/EazFixer/Options.cs
+++ b/EazFixer/Options.cs
@@ -12,10 +12,38 @@ namespace EazFixer
         [Option("out")]
         public string OutFile { get; set; }
 
-        [Option("keep-types")]
+        [Option("keep-types", HelpText = "Don't cleanup/remove obfuscator types")]
         public bool KeepTypes { get; set; }
 
-        [Option("virt-fix")]
+        [Option("virt-fix", HelpText = "Don't process obfuscated parts necessary for the code virtualization to work")]
         public bool VirtFix { get; set; }
+        
+        [Option("preserve-all", HelpText = "Preserve all metadata")]
+        public bool PreserveAll { get; set; }
+        
+        [Option("str-decrypt-tok", Default = "0", HelpText = "Manually specify string decryptor method token for if detection fails (Format: 0x<token>) ")]
+        public string StrDecTok { get; set; }
+        
+        [Option("res-resolver-tok", Default = "0", HelpText =  "Manually specify resource resolver type token for if detection fails (Format: 0x<token>) ")]
+        public string ResResolverTok { get; set; }
+        
+        [Option("res-init-tok", Default = "0", HelpText =  "Manually specify resource init method token for if detection fails (Format: 0x<token>) ")]
+        public string ResInitTok { get; set; }
+        
+        [Option("asmres-type-tok", Default = "0", HelpText = "Manually specify assembly decryptor type token for if detection fails (Format: 0x<token>) ")]
+        public string AsmResTypeTok { get; set; }
+        
+        [Option("asmres-movenext-tok", Default = "0", HelpText = "Manually specify assembly decryptor MoveNext token for if detection fails (Format: 0x<token>) ")]
+        public string AsmResMoveNextTok { get; set; }
+        
+        [Option("asmres-decompress-tok", Default = "0", HelpText = "Manually specify assembly decompressor method token for if detection fails (Format: 0x<token>) ")]
+        public string AsmResDecompressTok { get; set; }
+        
+        [Option("asmres-decrypt-tok", Default = "0", HelpText = "Manually specify assembly decryptor method token for if detection fails (Format: 0x<token>) ")]
+        public string AsmResDecryptTok { get; set; }
+        
+        [Option("ignore-tok-verification", HelpText = "Ignore the verification of manually set tokens. (Ensure your tokens are correct!)")]
+        public bool IgnoreTokVerification { get; set; }
+
     }
 }

--- a/EazFixer/Processors/AssemblyResolver.cs
+++ b/EazFixer/Processors/AssemblyResolver.cs
@@ -23,27 +23,15 @@ namespace EazFixer.Processors
             //try to find the embedded assemblies string, which is located in 
             //the iterator in the EnumerateEmbeddedAssemblies function
             if (!Flags.AsmResTypeTok.IsNull)
-            {
-                _assemblyResolver = Ctx.Module.ResolveToken(Flags.AsmResTypeTok) as TypeDef;
-                if (_assemblyResolver == null)
-                    throw new Exception("AssemblyResolver token set but type not found");
-                
-                if (!Flags.IgnoreTokVerification && !CanBeAssemblyResolver(_assemblyResolver))
-                    throw new Exception("AssemblyResolver found but is not a valid decrypter (Use --ignore-tok-verification to bypass this check)");
-            }
+                _assemblyResolver = Ctx.Module.ResolveToken(Flags.AsmResTypeTok) as TypeDef
+                                    ?? throw new Exception("AssemblyResolver token set but type not found");
             else
                 _assemblyResolver = Ctx.Module.Types.SingleOrDefault(CanBeAssemblyResolver)
                                     ?? throw new Exception("Could not find resolver type");
-            
+
             if (!Flags.AsmResMoveNextTok.IsNull)
-            {
-                _moveNext = Ctx.Module.ResolveToken(Flags.AsmResMoveNextTok) as MethodDef;
-                if (_moveNext == null)
-                    throw new Exception("MoveNext token set but type not found");
-                
-                if (!Flags.IgnoreTokVerification && !CanBeAssemblyResolver(_assemblyResolver))
-                    throw new Exception("MoveNext found but is not a valid decrypter (Use --ignore-tok-verification to bypass this check)");
-            }
+                _moveNext = Ctx.Module.ResolveToken(Flags.AsmResMoveNextTok) as MethodDef
+                            ?? throw new Exception("MoveNext token set but type not found");
             else
             {
                 var extractionApi = _assemblyResolver.NestedTypes.SingleOrDefault(CanBeExtractionApi)
@@ -58,14 +46,8 @@ namespace EazFixer.Processors
 
             MethodDef dec1;
             if (!Flags.AsmResDecryptTok.IsNull)
-            {
-                dec1 = Ctx.Module.ResolveToken(Flags.AsmResDecryptTok) as MethodDef;
-                if (dec1 == null)
-                    throw new Exception("Decrypter token set but method not found");
-
-                if (!Flags.IgnoreTokVerification && !CanBeDecryptionMethod(dec1))
-                    throw new Exception("Decrypter found but is not a valid assembly decrypter (Use --ignore-tok-verification to bypass this check)");
-            }
+                dec1 = Ctx.Module.ResolveToken(Flags.AsmResDecryptTok) as MethodDef
+                       ?? throw new Exception("Decrypter token set but method not found");
             else
                 dec1 = _assemblyResolver.Methods.SingleOrDefault(CanBeDecryptionMethod)
                        ?? throw new Exception("Could not find decryption method");
@@ -75,17 +57,12 @@ namespace EazFixer.Processors
 
             MethodDef dec2;
             if (!Flags.AsmResDecompressTok.IsNull)
-            {
-                dec2 = Ctx.Module.ResolveToken(Flags.AsmResDecompressTok) as MethodDef; //this one may be null
-                if (dec2 == null)
-                    throw new Exception("Decompressor token set but method not found");
-
-                if (!Flags.IgnoreTokVerification && !CanBeDecompressionMethod(dec2))
-                    throw new Exception("Decompressor found but is not a valid assembly decompressor (Use --ignore-tok-verification to bypass this check)");
-            }
+                dec2 = Ctx.Module.ResolveToken(Flags.AsmResDecompressTok) as MethodDef
+                        ?? throw new Exception("Decompressor token set but method not found");
             else
                 dec2 = _assemblyResolver.Methods.SingleOrDefault(CanBeDecompressionMethod);
 
+            //this one may be null
             if (dec2 != null)
                 _decompressor = Utils.FindMethod(Ctx.Assembly, dec2, new[] {typeof(byte[])})
                                 ?? throw new Exception("Couldn't find prefix remover through reflection");

--- a/EazFixer/Processors/AssemblyResolver.cs
+++ b/EazFixer/Processors/AssemblyResolver.cs
@@ -22,25 +22,73 @@ namespace EazFixer.Processors
         {
             //try to find the embedded assemblies string, which is located in 
             //the iterator in the EnumerateEmbeddedAssemblies function
-            _assemblyResolver = Ctx.Module.Types.SingleOrDefault(CanBeAssemblyResolver)
-                                ?? throw new Exception("Could not find resolver type");
-            var extractionApi = _assemblyResolver.NestedTypes.SingleOrDefault(CanBeExtractionApi)
-                                ?? throw new Exception("Could not find assembly extraction helper");
-            var enumerable = extractionApi.NestedTypes.SingleOrDefault(CanBeEnumerable)
-                                ?? throw new Exception("Could not find EnumerateEmbeddedAssemblies iterator");
-            _moveNext = enumerable.Methods.SingleOrDefault(CanBeMoveNext)
-                                ?? throw new Exception("Could not find EnumerateEmbeddedAssemblies's MoveNext");
+            if (!Flags.AsmResTypeTok.IsNull)
+            {
+                _assemblyResolver = Ctx.Module.ResolveToken(Flags.AsmResTypeTok) as TypeDef;
+                if (_assemblyResolver == null)
+                    throw new Exception("AssemblyResolver token set but type not found");
+                
+                if (!Flags.IgnoreTokVerification && !CanBeAssemblyResolver(_assemblyResolver))
+                    throw new Exception("AssemblyResolver found but is not a valid decrypter (Use --ignore-tok-verification to bypass this check)");
+            }
+            else
+                _assemblyResolver = Ctx.Module.Types.SingleOrDefault(CanBeAssemblyResolver)
+                                    ?? throw new Exception("Could not find resolver type");
+            
+            if (!Flags.AsmResMoveNextTok.IsNull)
+            {
+                _moveNext = Ctx.Module.ResolveToken(Flags.AsmResMoveNextTok) as MethodDef;
+                if (_moveNext == null)
+                    throw new Exception("MoveNext token set but type not found");
+                
+                if (!Flags.IgnoreTokVerification && !CanBeAssemblyResolver(_assemblyResolver))
+                    throw new Exception("MoveNext found but is not a valid decrypter (Use --ignore-tok-verification to bypass this check)");
+            }
+            else
+            {
+                var extractionApi = _assemblyResolver.NestedTypes.SingleOrDefault(CanBeExtractionApi)
+                                    ?? throw new Exception("Could not find assembly extraction helper");
+                var enumerable = extractionApi.NestedTypes.SingleOrDefault(CanBeEnumerable)
+                                 ?? throw new Exception("Could not find EnumerateEmbeddedAssemblies iterator");
+                _moveNext = enumerable.Methods.SingleOrDefault(CanBeMoveNext)
+                            ?? throw new Exception("Could not find EnumerateEmbeddedAssemblies's MoveNext");  
+            }
 
             //find the decryption methods
-            var dec1 = _assemblyResolver.Methods.SingleOrDefault(CanBeDecryptionMethod)
-                                ?? throw new Exception("Could not find decryption method");
-            _decrypter = Utils.FindMethod(Ctx.Assembly, dec1, new[] {typeof(byte[])}) 
-                ?? throw new Exception("Couldn't find decrypter through reflection");
 
-            var dec2 = _assemblyResolver.Methods.SingleOrDefault(CanBeDecompressionMethod);       //this one may be null
+            MethodDef dec1;
+            if (!Flags.AsmResDecryptTok.IsNull)
+            {
+                dec1 = Ctx.Module.ResolveToken(Flags.AsmResDecryptTok) as MethodDef;
+                if (dec1 == null)
+                    throw new Exception("Decrypter token set but method not found");
+
+                if (!Flags.IgnoreTokVerification && !CanBeDecryptionMethod(dec1))
+                    throw new Exception("Decrypter found but is not a valid assembly decrypter (Use --ignore-tok-verification to bypass this check)");
+            }
+            else
+                dec1 = _assemblyResolver.Methods.SingleOrDefault(CanBeDecryptionMethod)
+                       ?? throw new Exception("Could not find decryption method");
+
+            _decrypter = Utils.FindMethod(Ctx.Assembly, dec1, new[] { typeof(byte[]) })
+                         ?? throw new Exception("Couldn't find decrypter through reflection");
+
+            MethodDef dec2;
+            if (!Flags.AsmResDecompressTok.IsNull)
+            {
+                dec2 = Ctx.Module.ResolveToken(Flags.AsmResDecompressTok) as MethodDef; //this one may be null
+                if (dec2 == null)
+                    throw new Exception("Decompressor token set but method not found");
+
+                if (!Flags.IgnoreTokVerification && !CanBeDecompressionMethod(dec2))
+                    throw new Exception("Decompressor found but is not a valid assembly decompressor (Use --ignore-tok-verification to bypass this check)");
+            }
+            else
+                dec2 = _assemblyResolver.Methods.SingleOrDefault(CanBeDecompressionMethod);
+
             if (dec2 != null)
                 _decompressor = Utils.FindMethod(Ctx.Assembly, dec2, new[] {typeof(byte[])})
-                                 ?? throw new Exception("Couldn't find prefix remover through reflection");
+                                ?? throw new Exception("Couldn't find prefix remover through reflection");
         }
 
         protected override void ProcessInternal()

--- a/EazFixer/Processors/ResourceResolver.cs
+++ b/EazFixer/Processors/ResourceResolver.cs
@@ -19,27 +19,15 @@ namespace EazFixer.Processors
         {
             //find all "Resources" classes, and store them for later use
             if (!Flags.ResResolverTok.IsNull)
-            {
-                _resourceResolver = Ctx.Module.ResolveToken(Flags.ResResolverTok) as TypeDef;
-                if (_resourceResolver == null)
-                    throw new Exception("ResourceResolver token set but token not found");
-
-                if (!Flags.IgnoreTokVerification && !CanBeResourceResolver(_resourceResolver))
-                    throw new Exception("ResourceResolver found but is not a valid resource resolver (Use --ignore-tok-verification to bypass this check)");
-            }
+                _resourceResolver = Ctx.Module.ResolveToken(Flags.ResResolverTok) as TypeDef
+                                    ?? throw new Exception("ResourceResolver token set but token not found");
             else
                 _resourceResolver = Ctx.Module.Types.SingleOrDefault(CanBeResourceResolver)
                                     ?? throw new Exception("Could not find resolver type");
 
             if (!Flags.ResInitTok.IsNull)
-            {
-                _initMethod = Ctx.Module.ResolveToken(Flags.ResInitTok) as MethodDef;
-                if (_initMethod == null)
-                    throw new Exception("InitMethod token set but method not found");
-
-                if (!Flags.IgnoreTokVerification && !CanBeInitMethod(_initMethod))
-                    throw new Exception("InitMethod found but method is not a valid resource init method (Use --ignore-tok-verification to bypass this check)");
-            }
+                _initMethod = Ctx.Module.ResolveToken(Flags.ResInitTok) as MethodDef
+                              ?? throw new Exception("InitMethod token set but method not found");
             else
                 _initMethod = _resourceResolver.Methods.SingleOrDefault(CanBeInitMethod)
                               ?? throw new Exception("Could not find init method");

--- a/EazFixer/Processors/StringFixer.cs
+++ b/EazFixer/Processors/StringFixer.cs
@@ -14,14 +14,8 @@ namespace EazFixer.Processors
         {
             //find method
             if (!Flags.StrDecTok.IsNull)
-            {
-                _decrypterMethod = Ctx.Module.ResolveToken(Flags.StrDecTok) as MethodDef;
-                if (_decrypterMethod == null)
-                    throw new Exception("StringDecrypter token set but method not found");
-                
-                if (!Flags.IgnoreTokVerification && !StringFixUtils.CanBeStringMethod(_decrypterMethod))
-                    throw new Exception("StringDecrypter found but is not a valid decrypter (Use --ignore-tok-verification to bypass this check)");
-            }
+                _decrypterMethod = Ctx.Module.ResolveToken(Flags.StrDecTok) as MethodDef
+                                    ?? throw new Exception("StringDecrypter token set but method not found");
             else
                 _decrypterMethod = StringFixUtils.FindStringDecryptMethod(Ctx.Module) ??
                                throw new Exception("Could not find decrypter method");

--- a/EazFixer/Processors/StringFixer.cs
+++ b/EazFixer/Processors/StringFixer.cs
@@ -13,7 +13,17 @@ namespace EazFixer.Processors
         protected override void InitializeInternal()
         {
             //find method
-            _decrypterMethod = StringFixUtils.FindStringDecryptMethod(Ctx.Module) ??
+            if (!Flags.StrDecTok.IsNull)
+            {
+                _decrypterMethod = Ctx.Module.ResolveToken(Flags.StrDecTok) as MethodDef;
+                if (_decrypterMethod == null)
+                    throw new Exception("StringDecrypter token set but method not found");
+                
+                if (!Flags.IgnoreTokVerification && !StringFixUtils.CanBeStringMethod(_decrypterMethod))
+                    throw new Exception("StringDecrypter found but is not a valid decrypter (Use --ignore-tok-verification to bypass this check)");
+            }
+            else
+                _decrypterMethod = StringFixUtils.FindStringDecryptMethod(Ctx.Module) ??
                                throw new Exception("Could not find decrypter method");
         }
 

--- a/EazFixer/Program.cs
+++ b/EazFixer/Program.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CommandLine;
+using dnlib.DotNet;
+using dnlib.DotNet.Writer;
 using EazFixer.Processors;
 
 namespace EazFixer
@@ -19,7 +21,7 @@ namespace EazFixer
 
                 //order is important! AssemblyResolver has to be after StringFixer and ResourceResolver
                 var ctx = new EazContext(!string.IsNullOrEmpty(Flags.InFile) ? Flags.InFile : throw new Exception("Filepath not defined!"), 
-                    new ProcessorBase[] {new StringFixer(), new ResourceResolver(), new AssemblyResolver()});
+                    new ProcessorBase[] {new StringFixer(), new ResourceResolver(), new Processors.AssemblyResolver()});
 
                 Console.WriteLine("Executing memory patches...");
                 StacktracePatcher.Patch();
@@ -61,7 +63,7 @@ namespace EazFixer
                 Console.WriteLine();
 
                 Console.WriteLine("Writing new assembly...");
-                ctx.Module.Write(Flags.OutFile);
+                ctx.Module.Write(Flags.OutFile, new ModuleWriterOptions(ctx.Module) { MetadataOptions= new MetadataOptions(Flags.PreserveAll ? MetadataFlags.PreserveAll : 0) });
 
 #if DEBUG
                 return Exit("DONE", true);
@@ -93,6 +95,15 @@ namespace EazFixer
             Flags.InFile = args.InFile;
             Flags.KeepTypes = args.KeepTypes;
             Flags.VirtFix = args.VirtFix;
+            Flags.PreserveAll = args.PreserveAll;
+            Flags.StrDecTok = new MDToken(Convert.ToUInt32(args.StrDecTok, 16));
+            Flags.ResResolverTok = new MDToken(Convert.ToUInt32(args.ResResolverTok, 16));
+            Flags.ResInitTok = new MDToken(Convert.ToUInt32(args.ResInitTok, 16));
+            Flags.AsmResDecompressTok = new MDToken(Convert.ToUInt32(args.AsmResDecompressTok, 16));
+            Flags.AsmResDecryptTok = new MDToken(Convert.ToUInt32(args.AsmResDecryptTok, 16));
+            Flags.AsmResTypeTok = new MDToken(Convert.ToUInt32(args.AsmResTypeTok, 16));
+            Flags.AsmResMoveNextTok = new MDToken(Convert.ToUInt32(args.AsmResMoveNextTok, 16));
+            Flags.IgnoreTokVerification = args.IgnoreTokVerification;
 
             if (args.OutFile != default)
             {

--- a/EazFixer/Program.cs
+++ b/EazFixer/Program.cs
@@ -103,8 +103,7 @@ namespace EazFixer
             Flags.AsmResDecryptTok = new MDToken(Convert.ToUInt32(args.AsmResDecryptTok, 16));
             Flags.AsmResTypeTok = new MDToken(Convert.ToUInt32(args.AsmResTypeTok, 16));
             Flags.AsmResMoveNextTok = new MDToken(Convert.ToUInt32(args.AsmResMoveNextTok, 16));
-            Flags.IgnoreTokVerification = args.IgnoreTokVerification;
-
+            
             if (args.OutFile != default)
             {
                 Flags.OutFile = args.OutFile;

--- a/EazFixer/StringFixUtils.cs
+++ b/EazFixer/StringFixUtils.cs
@@ -11,7 +11,7 @@ namespace EazFixer
             return Utils.GetMethodsRecursive(module).SingleOrDefault(CanBeStringMethod);
         }
 
-        private static bool CanBeStringMethod(MethodDef method)
+        public static bool CanBeStringMethod(MethodDef method)
         {
             //internal and static
             if (!method.IsStatic || !method.IsAssembly)

--- a/EazFixer/StringFixUtils.cs
+++ b/EazFixer/StringFixUtils.cs
@@ -11,7 +11,7 @@ namespace EazFixer
             return Utils.GetMethodsRecursive(module).SingleOrDefault(CanBeStringMethod);
         }
 
-        public static bool CanBeStringMethod(MethodDef method)
+        private static bool CanBeStringMethod(MethodDef method)
         {
             //internal and static
             if (!method.IsStatic || !method.IsAssembly)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ If your assembly is protected with control-flow obfuscation, run it through [de4
 * --asmres-movenext-tok
 * --asmres-decrypt-tok
 * --asmres-decompress-tok
-* --ignore-tok-verification
 
 The flag `--file` is used for the input file.
 The flag `--keep-types` is similar to the de4dot flag, Keeps obfuscator types and assemblies.
@@ -54,7 +53,6 @@ The flag `--asmres-type-tok` is used to manually specify the assembly resolver t
 The flag `--asmres-movenext-tok` is used to manually specify the assembly resolver MoveNext method token.
 The flag `--asmres-decompress-tok` is used to manually specify the assembly resource decompression method token.
 The flag `--asmres-decrypt-tok` is used to manually specify the assembly resource decryption method token.
-The flag `--ignore-tok-verification` ignores the method verification of explicitly set tokens in the above flags. (Ensure your method tokens are correct!)
 
 example: `EazFixer.exe --file test.exe --keep-types`
 

--- a/README.md
+++ b/README.md
@@ -28,31 +28,32 @@ EazFixer is a deobfuscation tool for [Eazfuscator](https://www.gapotchenko.com/e
 Call from the command line or drag and drop the file on and let it run or use the command line flag `--file`.
 
 If your assembly is protected with control-flow obfuscation, run it through [de4dot](https://github.com/0xd4d/de4dot) with the
-`--only-cflow-deob` flag first. This could break the AssemblyResolver processor's method detection, so you may need to use `--asmres-tok 0x<token>`
+`--only-cflow-deob` flag first. This could break the AssemblyResolver processor's method detection, so you may need to manually find the AssemblyResolver tokens and use the `--asmres-decrypt-tok` and `--asmres-decompress-tok` flags.
 
 * --file path
+    * input file
 * --keep-types
+    * similar to the de4dot flag, keeps obfuscator types and assemblies
 * --virt-fix
+    * keeps certain parts obfuscated to stay working with [virtualized](https://help.gapotchenko.com/eazfuscator.net/30/virtualization) assemblies.
 * --preserve-all
-* --str-decrypt-tok
-* --res-resolver-tok
-* --res-init-tok
-* --asmres-type-tok
-* --asmres-movenext-tok
-* --asmres-decrypt-tok
-* --asmres-decompress-tok
+    * preserves all metadata
 
-The flag `--file` is used for the input file.
-The flag `--keep-types` is similar to the de4dot flag, Keeps obfuscator types and assemblies.
-The flag `--virt-fix` keeps certain parts obfuscated to stay working with [virtualized](https://help.gapotchenko.com/eazfuscator.net/30/virtualization) assemblies.
-The flag `--preserve-all` preserves all metadata.
-The flag `--str-decrypt-tok` is used to manually specify the string decryption method token manually.
-The flag `--res-resolver-tok` is used to manually specify the resource resolver type token manually.
-The flag `--res-init-tok` is used to manually specify the resource initialization method token manually.
-The flag `--asmres-type-tok` is used to manually specify the assembly resolver type token.
-The flag `--asmres-movenext-tok` is used to manually specify the assembly resolver MoveNext method token.
-The flag `--asmres-decompress-tok` is used to manually specify the assembly resource decompression method token.
-The flag `--asmres-decrypt-tok` is used to manually specify the assembly resource decryption method token.
+The following flags are for manually specifying metadata tokens in the case EazFixer fails to find them. They accept the token in hex format. e.g. `--str-decrypt-tok 0x060002B7`
+* --str-decrypt-tok
+    * string decryption method
+* --res-resolver-tok
+    * resource resolver type
+* --res-init-tok
+    * resource initialization method
+* --asmres-type-tok
+    * assembly resolver type
+* --asmres-movenext-tok
+    * assembly resolver's MoveNext implementation method token
+* --asmres-decrypt-tok
+    * assembly resolver's decryption method
+* --asmres-decompress-tok
+    * assembly resolver's decompression method
 
 example: `EazFixer.exe --file test.exe --keep-types`
 
@@ -60,11 +61,11 @@ example: `EazFixer.exe --file test.exe --keep-types`
 Clone the repository and use the latest version of Visual Studio (2019, at the time of writing).
 
 ## Support
-EazFixer is (and will always be) targeted at the latest version of Eazfuscator. If your version is not supported, try a more universal 
-deobfuscator like [de4dot](https://github.com/0xd4d/de4dot). If your version is newer than what this tool supports, create an issue only 
+EazFixer is (and will always be) targeted at the latest version of Eazfuscator. If your version is not supported, try a more universal
+deobfuscator like [de4dot](https://github.com/0xd4d/de4dot). If your version is newer than what this tool supports, create an issue only
 **after** verifying with the latest version of Eazfuscator.
 
-Also, I will not help you use this program. Consider it for advanced users only. If you do run into a problem and are sure it is a bug, 
+Also, I will not help you use this program. Consider it for advanced users only. If you do run into a problem and are sure it is a bug,
 feel free to submit an issue but I cannot guarantee I will fix it.
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -28,15 +28,33 @@ EazFixer is a deobfuscation tool for [Eazfuscator](https://www.gapotchenko.com/e
 Call from the command line or drag and drop the file on and let it run or use the command line flag `--file`.
 
 If your assembly is protected with control-flow obfuscation, run it through [de4dot](https://github.com/0xd4d/de4dot) with the
-`--only-cflow-deob` flag first.
+`--only-cflow-deob` flag first. This could break the AssemblyResolver processor's method detection, so you may need to use `--asmres-tok 0x<token>`
 
 * --file path
 * --keep-types
 * --virt-fix
+* --preserve-all
+* --str-decrypt-tok
+* --res-resolver-tok
+* --res-init-tok
+* --asmres-type-tok
+* --asmres-movenext-tok
+* --asmres-decrypt-tok
+* --asmres-decompress-tok
+* --ignore-tok-verification
 
 The flag `--file` is used for the input file.
 The flag `--keep-types` is similar to the de4dot flag, Keeps obfuscator types and assemblies.
 The flag `--virt-fix` keeps certain parts obfuscated to stay working with [virtualized](https://help.gapotchenko.com/eazfuscator.net/30/virtualization) assemblies.
+The flag `--preserve-all` preserves all metadata.
+The flag `--str-decrypt-tok` is used to manually specify the string decryption method token manually.
+The flag `--res-resolver-tok` is used to manually specify the resource resolver type token manually.
+The flag `--res-init-tok` is used to manually specify the resource initialization method token manually.
+The flag `--asmres-type-tok` is used to manually specify the assembly resolver type token.
+The flag `--asmres-movenext-tok` is used to manually specify the assembly resolver MoveNext method token.
+The flag `--asmres-decompress-tok` is used to manually specify the assembly resource decompression method token.
+The flag `--asmres-decrypt-tok` is used to manually specify the assembly resource decryption method token.
+The flag `--ignore-tok-verification` ignores the method verification of explicitly set tokens in the above flags. (Ensure your method tokens are correct!)
 
 example: `EazFixer.exe --file test.exe --keep-types`
 


### PR DESCRIPTION
This PR adds various options for manually specifying tokens for the various processors. e.g. string decryptor method, assembly resolver decryptor, etc.

I also added a preserve all option for #19

I also added a note in the readme about the AssemblyResolver & de4dot. De4dot can remove the inlining flag we use to differentiate the decryption and decompressor methods (even with the --preserve options!). It's also why I did this in the first place. I was going to make the check less fragile, but I figured it was only using the signature in case the body is obfuscated or something. Otherwise it would be simple to just check the body instructions. If you think it's a good idea though I can do that in another PR.

---

Closes #19 